### PR TITLE
Allow permissioned ambassadors to add leaders to clubs

### DIFF
--- a/src/interactions/leaderAdd.js
+++ b/src/interactions/leaderAdd.js
@@ -18,7 +18,7 @@ const interactionLeaderAdd = (bot, message) => {
         return
       }
 
-      if (!commandUser.club) {
+      if (!(commandUser.club && commandUser.ambassador)) {
         console.log(`${commandUser.user} doesn't have a club`)
         bot.replyPrivateDelayed(message, transcript('leaderAdd.invalidClub'))
         return

--- a/src/interactions/leaderAdd.js
+++ b/src/interactions/leaderAdd.js
@@ -18,7 +18,7 @@ const interactionLeaderAdd = (bot, message) => {
         return
       }
 
-      if (!(commandUser.club && commandUser.ambassador)) {
+      if (!(commandUser.club && commandUser.permissionedAmbassador)) {
         console.log(`${commandUser.user} doesn't have a club`)
         bot.replyPrivateDelayed(message, transcript('leaderAdd.invalidClub'))
         return

--- a/src/interactions/leaderAdd.js
+++ b/src/interactions/leaderAdd.js
@@ -1,101 +1,40 @@
-import { getInfoForUser, airCreate, airPatch, transcript } from '../utils'
+import { getInfoForUser, airPatch, transcript, airFind } from '../utils'
 
-const interactionLeaderAdd = (bot, message) => {
+const interactionLeaderAdd = async (bot, message) => {
   const { user, text, channel } = message
 
-  if (text === '' || text === 'help') {
+  const taggedUserID = (text.match(/\<@(.*)\|/) || [])[1]
+  if (!taggedUserID) {
     bot.replyPrivateDelayed(message, transcript('leaderAdd.help'))
-    return
   }
 
-  return getInfoForUser(user)
-    .then(commandUser => {
-      if (!commandUser.leader) {
-        console.log(
-          `${commandUser.user} isn't a leader, so I told them this was restricted`
-        )
-        bot.replyPrivateDelayed(message, transcript('leaderAdd.invalidUser'))
-        return
-      }
+  const taggedUser = await getInfoForUser(taggedUserID)
+  const commandUser = await getInfoForUser(user)
+  const recipientClub = await airFind('Clubs', 'Slack Channel ID', channel)
 
-      if (!commandUser.club && commandUser.permissionedAmbassador === "false") {
-        console.log(`${commandUser.user} doesn't have a club`)
-        bot.replyPrivateDelayed(message, transcript('leaderAdd.invalidClub'))
-        return
-      }
+  if (!commandUser.club && !commandUser.permissionedAmbassador) {
+    throw transcript('leaderAdd.invalidClub')
+  }
 
-      if (commandUser.club.fields['Slack Channel ID'] != channel) {
-        console.log(`${user} doesn't own channel ${channel}`)
-        bot.replyPrivateDelayed(message, transcript('leaderAdd.invalidChannel'))
-        return
-      }
+  if (commandUser.club && commandUser.club.id != recipientClub.id) {
+    // A leader is trying to permission someone to a channel that's not their
+    // club channel
+    throw transcript('leaderAdd.invalidChannel')
+  }
 
-      const taggedUserID = (message.text.match(/\<@(.*)\|/) || [])[1]
-      if (!taggedUserID) {
-        throw new Error('Invalid Slack user')
-      }
+  const taggedUserClubs = taggedUser.fields['Clubs'] || []
+  if (taggedUserClubs.includes(recipientClub)) {
+    throw transcript('leaderAdd.alreadyLeader')
+  }
 
-      return getInfoForUser(taggedUserID)
-        .then(taggedUser => {
-          console.log('found tagged user')
-          if (taggedUser.slackUser.is_bot) {
-            throw new Error('bots cannot be club leaders')
-          }
-          if (!taggedUser.person) {
-            // if user doesn't exist in Airtable
-            const profile = taggedUser.slackUser.profile
-            const fields = {
-              Email: taggedUser.slackUser.profile.email,
-              'Slack ID': taggedUser.slackUser.id,
-              'Full Name': profile.real_name || profile.display_name,
-            }
-            console.log(fields)
-            return airCreate('Person', fields)
-              .then(taggedPerson => {
-                return taggedPerson
-              })
-              .catch(err => {
-                console.error(
-                  'Ran into issue creating new Person record in Airtable'
-                )
-                throw err
-              })
-          } else {
-            return taggedUser.person
-          }
-        })
-        .then(taggedPerson => {
-          // ensure we can assign the person as a leader to this club
-          const clubs = taggedPerson.fields['Clubs'] || []
-          if (clubs.includes(commandUser.club.id)) {
-            bot.replyPrivateDelayed(
-              message,
-              transcript('leaderAdd.alreadyLeader')
-            )
-            return
-          }
-          clubs.push(commandUser.club.id)
-          return airPatch('People', taggedPerson.id, {
-            Clubs: clubs,
-          })
-            .then(() => {
-              bot.replyPrivateDelayed(
-                message,
-                transcript('leaderAdd.success', { taggedUserID, channel })
-              )
-            })
-            .catch(err => {
-              throw err
-            })
-        })
-        .catch(err => {
-          throw err
-        })
-    })
-    .catch(err => {
-      console.error(err)
-      bot.replyPrivateDelayed(message, transcript('errors.general', { err }))
-    })
+  await airPatch('People', taggedUser.id, {
+    Clubs: [...taggedUserClubs, recipientClub],
+  })
+
+  bot.replyPrivateDelayed(
+    message,
+    transcript('leaderAdd.success', { taggedUserID, channel })
+  )
 }
 
 export default interactionLeaderAdd

--- a/src/interactions/leaderAdd.js
+++ b/src/interactions/leaderAdd.js
@@ -18,7 +18,7 @@ const interactionLeaderAdd = (bot, message) => {
         return
       }
 
-      if (!(commandUser.club && commandUser.permissionedAmbassador)) {
+      if (!commandUser.club && commandUser.permissionedAmbassador === "false") {
         console.log(`${commandUser.user} doesn't have a club`)
         bot.replyPrivateDelayed(message, transcript('leaderAdd.invalidClub'))
         return

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -251,7 +251,7 @@ export const getInfoForUser = user =>
       airFind('People', 'Slack ID', user).then(
         person => (results.person = person)
       ),
-      airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false"').then(
+      airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false")').then(
         permissionedAmbassador => {
           results.permissionedAmbassador = permissionedAmbassador
         }

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -251,7 +251,7 @@ export const getInfoForUser = user =>
       airFind('People', 'Slack ID', user).then(
         person => (results.person = person)
       ),
-      airGet('Ambassadors', `FIND('${user}', {Slack ID})`).then(
+      airFind('Ambassadors', 'Slack ID', user).then(
         () => {
           airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false")').then(
             permissionedAmbassador => {

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -42,7 +42,7 @@ export const airPatch = (baseName, recordID, values, options = {}) =>
           }
           console.log(
             `Airtable updated my ${baseName} record from ${timestamp} in ${Date.now() -
-            timestamp}ms`
+              timestamp}ms`
           )
           resolve(record)
         })
@@ -69,7 +69,7 @@ export const airCreate = (baseName, fields, options = {}) =>
           }
           console.log(
             `Airtable saved my ${baseName} record from ${timestamp} in ${Date.now() -
-            timestamp}ms`
+              timestamp}ms`
           )
           resolve(record)
         })
@@ -134,7 +134,7 @@ export const airGet = (
             }
             console.log(
               `AirTable got back to me from my question at ${timestamp} with ${
-              data.length
+                data.length
               } records. The query took ${Date.now() - timestamp}ms`
             )
             resolve(data)
@@ -251,15 +251,12 @@ export const getInfoForUser = user =>
       airFind('People', 'Slack ID', user).then(
         person => (results.person = person)
       ),
-      airFind('Ambassadors', 'Slack ID', user).then(
-        () => {
-          airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false")').then(
-            permissionedAmbassador => {
-              results.permissionedAmbassador = permissionedAmbassador
-            }
-          )
+      airFind('Ambassadors', 'Slack ID', user).then(ambassador => {
+        results.ambassador = ambassador
+        if (ambassador) {
+          results.permissionedAmbassador = ambassador.fields['Permissioned']
         }
-      )
+      }),
     ])
       .then(async () => {
         if (!results.person && results.slackUser) {
@@ -325,7 +322,7 @@ export const getInfoForUser = user =>
       .then(() => {
         console.log(
           `Finished pulling up the info about user '${user}' from ${timestamp} in ${Date.now() -
-          timestamp}ms`
+            timestamp}ms`
         )
         resolve(results)
       })
@@ -513,7 +510,7 @@ export const transcript = (search, vars) => {
   return evalTranscript(recurseTranscript(searchArr, transcriptObj), vars)
 }
 const evalTranscript = (target, vars = {}) =>
-  function () {
+  function() {
     return eval('`' + target + '`')
   }.call({
     ...vars,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -251,9 +251,13 @@ export const getInfoForUser = user =>
       airFind('People', 'Slack ID', user).then(
         person => (results.person = person)
       ),
-      airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false")').then(
-        permissionedAmbassador => {
-          results.permissionedAmbassador = permissionedAmbassador
+      airGet('Ambassadors', `FIND('${user}', {Slack ID})`).then(
+        () => {
+          airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false")').then(
+            permissionedAmbassador => {
+              results.permissionedAmbassador = permissionedAmbassador
+            }
+          )
         }
       )
     ])

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -251,13 +251,9 @@ export const getInfoForUser = user =>
       airFind('People', 'Slack ID', user).then(
         person => (results.person = person)
       ),
-      airFind('Ambassadors', 'Slack ID', user).then(
-        () => {
-          airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false"').then(
-            permissionedAmbassador => {
-              results.permissionedAmbassador = permissionedAmbassador
-            }
-          )
+      airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false"').then(
+        permissionedAmbassador => {
+          results.permissionedAmbassador = permissionedAmbassador
         }
       )
     ])

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -42,7 +42,7 @@ export const airPatch = (baseName, recordID, values, options = {}) =>
           }
           console.log(
             `Airtable updated my ${baseName} record from ${timestamp} in ${Date.now() -
-              timestamp}ms`
+            timestamp}ms`
           )
           resolve(record)
         })
@@ -69,7 +69,7 @@ export const airCreate = (baseName, fields, options = {}) =>
           }
           console.log(
             `Airtable saved my ${baseName} record from ${timestamp} in ${Date.now() -
-              timestamp}ms`
+            timestamp}ms`
           )
           resolve(record)
         })
@@ -134,7 +134,7 @@ export const airGet = (
             }
             console.log(
               `AirTable got back to me from my question at ${timestamp} with ${
-                data.length
+              data.length
               } records. The query took ${Date.now() - timestamp}ms`
             )
             resolve(data)
@@ -251,6 +251,15 @@ export const getInfoForUser = user =>
       airFind('People', 'Slack ID', user).then(
         person => (results.person = person)
       ),
+      airFind('Ambassadors', 'Slack ID', user).then(
+        () => {
+          airGet('Ambassadors', 'IF(Permissioned = 1, "true", "false"').then(
+            permissionedAmbassador => {
+              results.permissionedAmbassador = permissionedAmbassador
+            }
+          )
+        }
+      )
     ])
       .then(async () => {
         if (!results.person && results.slackUser) {
@@ -316,7 +325,7 @@ export const getInfoForUser = user =>
       .then(() => {
         console.log(
           `Finished pulling up the info about user '${user}' from ${timestamp} in ${Date.now() -
-            timestamp}ms`
+          timestamp}ms`
         )
         resolve(results)
       })
@@ -504,7 +513,7 @@ export const transcript = (search, vars) => {
   return evalTranscript(recurseTranscript(searchArr, transcriptObj), vars)
 }
 const evalTranscript = (target, vars = {}) =>
-  function() {
+  function () {
     return eval('`' + target + '`')
   }.call({
     ...vars,

--- a/src/utils/transcript.yml
+++ b/src/utils/transcript.yml
@@ -338,11 +338,10 @@ leaderAdd:
     Registers a new leader to your club. Ex. \`/leader-add @orpheus\`
     _Needs to be run by a club leader in their own club channel_
     Additionally, you can see a list of who is already a leader with \`/leader-list\`
-  invalidUser: Only club leaders can use this command.
-  invalidClub: I couldn't find your club.
+  invalidAuth: I couldn't find your club. Only registered leaders or operations team members can run this command.
   invalidChannel: This isn't your club channel. Please run this in a channel you lead.
-  success: And... done! I've added <@${this.taggedUserID}> to the club in <#${this.channel}>.
   alreadyLeader: They're already a leader in your club!
+  success: And... done! I've added <@${this.taggedUserID}> to the club in <#${this.channel}>.
 leaderList:
   invalidUser: Only club leaders can use this command.
   invalidClub: I couldn't find your club.


### PR DESCRIPTION
While attempting to transition leadership of Malagon Hack Club this morning, I realized it was impossible for me to add a new leader to their club, even as a permissioned ambassador, because I was not the owner of that club. This can become a major bottleneck in the future if previous leaders aren't available to run `/leader-add` in their channel, so this PR allows permissioned ambassadors to run this command on any club's channel.

This code is untested, but I think it should work.