### PR TITLE
Remove owner requirement for /airtable

### DIFF
--- a/src/interactions/airtable.js
+++ b/src/interactions/airtable.js
@@ -2,12 +2,6 @@ import { getInfoForUser, transcript } from '../utils'
 
 export default async (bot, message) => {
   try {
-    const { slackUser } = await getInfoForUser(message.user)
-
-    if (!slackUser.is_owner) {
-      throw new Error('Only Slack owners can run this command!')
-    }
-
     const taggedUserID = (message.text.match(/<@([a-zA-Z0-9]*)|/) || [])[1]
 
     if (!taggedUserID) {


### PR DESCRIPTION
It makes more sense to allow people who have access to the Operations Airtable to run this command rather than only workspace owners.