### PR TITLE
Restrict som-promote to admins

### DIFF
--- a/src/interactions/som/promote.js
+++ b/src/interactions/som/promote.js
@@ -48,6 +48,10 @@ const interactionSOMPromote = async (bot = initBot(), message) => {
     console.log('caller is restricted, cancelling')
     return
   }
+  if (!user.caller.slackUser.is_admin) {
+    console.log('caller is not an admin, cancelling')
+    bot.replyPrivateDelayed(message, transcript('som.approve.notAdmin'))
+  }
   if (!user.tagged.slackUser.is_restricted) {
     console.log('tagged is not restricted, cancelling')
     return

--- a/src/utils/transcript.yml
+++ b/src/utils/transcript.yml
@@ -461,6 +461,7 @@ som:
   approve:
     restricted: This can only be called by a full Slack user, not a guest.
     notRestricted: That user isn't a guest. I can only promote guests to full Slack users.
+    notAdmin: Only Slack admins can promote a user.
     notGuest: No guest history found for <@${this.user}>. I can't promote them to a full Slack user.
     alreadyApproved: That person already has a fully approved Slack account! There isn't anything more I can approve them for.
     success: 'https://www.youtube.com/watch?v=SBCw4_XgouA'


### PR DESCRIPTION
The Clippy tutorial assumes you’re a multi-channel guest, and the experience is worse if you don’t (e.g, the private channel #mmmmmm... appears as “private channel info” to multi-channel guests, but shows up once they finish). A few users in Slack have been instantly promoting people if they are a multi-channel guest and speak in #lobby. This PR restricts `/som-promote` to slack admins only.

I can’t tell if this is a bad idea that will annoy people—if you have opinions, I’m happy to chat about it