### PR TITLE
Add repl.it to /get & remove GitHub Grant

### DIFF
--- a/src/interactions/get.js
+++ b/src/interactions/get.js
@@ -1,18 +1,20 @@
 import { transcript, initBot } from '../utils'
-import * as githubGrant from './promos/githubGrant'
+//import * as githubGrant from './promos/githubGrant'
 import * as hackPack from './promos/hackPack'
 import * as stickerEnvelope from './promos/stickerEnvelope'
 import * as notionPremium from './promos/notionPremium'
 import * as stickermule from './promos/stickermule'
 import * as adafruitDiscount from './promos/adafruitDiscount'
 import * as zoom from './promos/zoom'
+import * as replitHackerPlan from './promos/replitHackerPlan'
 
 const promos = [
   stickerEnvelope,
   notionPremium,
   stickermule,
   hackPack,
-  githubGrant,
+  //githubGrant,
+  replitHackerPlan,
   adafruitDiscount,
   zoom,
 ]

--- a/src/interactions/promos/githubGrant.js
+++ b/src/interactions/promos/githubGrant.js
@@ -1,139 +1,139 @@
-// import {
-//   initBot,
-//   getInfoForUser,
-//   airFind,
-//   airCreate,
-//   transcript,
-// } from '../../utils'
-// import interactionMailMission from '../mailMission'
+import {
+  initBot,
+  getInfoForUser,
+  airFind,
+  airCreate,
+  transcript,
+} from '../../utils'
+import interactionMailMission from '../mailMission'
 
-// /*
-// to test
-// [ ] mailteam request vanilla grant
-// [ ] mailteam request recurring grant (valid)
-// [ ] mailteam request recurring grant (already had grant this semester)
-// [ ] hcb request vanilla grant
-// [ ] hcb request recurring grant (valid)
-// [ ] hcb request recurring grant (already had grant this semester)
-// [ ] request from non leader
-// */
-// export const names = ['GitHub Grant', 'club grant']
-// export const details =
-//   'Available to club leaders. Must have a meeting time set with `/meeting-time`'
+/*
+to test
+[ ] mailteam request vanilla grant
+[ ] mailteam request recurring grant (valid)
+[ ] mailteam request recurring grant (already had grant this semester)
+[ ] hcb request vanilla grant
+[ ] hcb request recurring grant (valid)
+[ ] hcb request recurring grant (already had grant this semester)
+[ ] request from non leader
+*/
+export const names = ['GitHub Grant', 'club grant']
+export const details =
+  'Available to club leaders. Must have a meeting time set with `/meeting-time`'
 
-// export async function run(bot, message) {
-//   const { user } = message
-//   const { leader, club, history, personAddress } = await getInfoForUser(user)
+export async function run(bot, message) {
+  const { user } = message
+  const { leader, club, history, personAddress } = await getInfoForUser(user)
 
-//   if (!leader || !club) {
-//     await bot.replyPrivateDelayed(
-//       message,
-//       transcript('promos.githubGrant.notAuthorized')
-//     )
-//     return
-//   }
+  if (!leader || !club) {
+    await bot.replyPrivateDelayed(
+      message,
+      transcript('promos.githubGrant.notAuthorized')
+    )
+    return
+  }
 
-//   await bot.replyPrivateDelayed(
-//     message,
-//     transcript('promos.githubGrant.programClosed')
-//   )
-//   return // we're closing down grants this semester until we get more funding from GitHub
+  await bot.replyPrivateDelayed(
+    message,
+    transcript('promos.githubGrant.programClosed')
+  )
+  return // we're closing down grants this semester until we get more funding from GitHub
 
-//   const lastGrant = await airFind(
-//     'GitHub Grants',
-//     `AND({Dummy} = 0, {Club} = '${club.fields['ID']}')`,
-//     null,
-//     {
-//       selectBy: {
-//         sort: [{ field: 'Initiated at', direction: 'desc' }],
-//       },
-//     }
-//   )
-//   if (!lastGrant) {
-//     // this is their first grant
-//     const grant = await airCreate('GitHub Grants', {
-//       Club: [club.id],
-//       Leader: [leader.id],
-//       Type: 'First meeting ($100)',
-//       'Grant amount': 100,
-//     })
+  const lastGrant = await airFind(
+    'GitHub Grants',
+    `AND({Dummy} = 0, {Club} = '${club.fields['ID']}')`,
+    null,
+    {
+      selectBy: {
+        sort: [{ field: 'Initiated at', direction: 'desc' }],
+      },
+    }
+  )
+  if (!lastGrant) {
+    // this is their first grant
+    const grant = await airCreate('GitHub Grants', {
+      Club: [club.id],
+      Leader: [leader.id],
+      Type: 'First meeting ($100)',
+      'Grant amount': 100,
+    })
 
-//     if (grant.fields['HCB Account']) {
-//       // if they have an HCB account, we'll notify the bank team
-//       await bot.replyPrivateDelayed(
-//         message,
-//         transcript('promos.githubGrant.hcbFulfillment', {
-//           hcbLink: grant.fields['HCB Account'],
-//         })
-//       )
-//     } else if (
-//       personAddress.fields['Country'] === 'United States of America (US)'
-//     ) {
-//       // if no HCB account, check if they're in the US. If so, setup a mail mission
-//       await interactionMailMission(undefined, {
-//         user,
-//         text: 'new_club_grant',
-//       })
-//       await bot.replyPrivateDelayed(
-//         message,
-//         transcript('promos.githubGrant.usShipping')
-//       )
-//     } else {
-//       // if no HCB account
-//       await bot.replyPrivateDelayed(
-//         message,
-//         transcript('promos.githubGrant.otherSuccess')
-//       )
-//     }
-//     return
-//   } else {
-//     // they've had a grant before
-//     const lastGrantDate = new Date(lastGrant.fields['Initiated at'])
-//     const today = new Date()
+    if (grant.fields['HCB Account']) {
+      // if they have an HCB account, we'll notify the bank team
+      await bot.replyPrivateDelayed(
+        message,
+        transcript('promos.githubGrant.hcbFulfillment', {
+          hcbLink: grant.fields['HCB Account'],
+        })
+      )
+    } else if (
+      personAddress.fields['Country'] === 'United States of America (US)'
+    ) {
+      // if no HCB account, check if they're in the US. If so, setup a mail mission
+      await interactionMailMission(undefined, {
+        user,
+        text: 'new_club_grant',
+      })
+      await bot.replyPrivateDelayed(
+        message,
+        transcript('promos.githubGrant.usShipping')
+      )
+    } else {
+      // if no HCB account
+      await bot.replyPrivateDelayed(
+        message,
+        transcript('promos.githubGrant.otherSuccess')
+      )
+    }
+    return
+  } else {
+    // they've had a grant before
+    const lastGrantDate = new Date(lastGrant.fields['Initiated at'])
+    const today = new Date()
 
-//     // our heuristic for keeping 1 grant per semester is to check if the last grant was both this semester & this year
-//     // semesters are defined as:
-//     // - first semester months are 6 through 11
-//     // - second semester months are 0 through 5
-//     const currentSemester = Math.floor(today.getMonth() / 5)
-//     const lastGrantSemester = Math.floor(lastGrantDate.getMonth() / 5)
+    // our heuristic for keeping 1 grant per semester is to check if the last grant was both this semester & this year
+    // semesters are defined as:
+    // - first semester months are 6 through 11
+    // - second semester months are 0 through 5
+    const currentSemester = Math.floor(today.getMonth() / 5)
+    const lastGrantSemester = Math.floor(lastGrantDate.getMonth() / 5)
 
-//     const hasSameYear = lastGrantDate.getYear() == today.getYear()
-//     const hasSameSemester = lastGrantSemester == currentSemester
-//     if (hasSameYear && hasSameSemester) {
-//       const requester = (
-//         await airFind(
-//           'People',
-//           `RECORD_ID() = '${lastGrant.fields['Leader'][0]}'`
-//         )
-//       ).fields['Slack ID']
-//       await bot.replyPrivateDelayed(
-//         message,
-//         transcript('promos.githubGrant.alreadyGranted', {
-//           lastGrantDate,
-//           requester,
-//         })
-//       )
-//       return
-//     }
+    const hasSameYear = lastGrantDate.getYear() == today.getYear()
+    const hasSameSemester = lastGrantSemester == currentSemester
+    if (hasSameYear && hasSameSemester) {
+      const requester = (
+        await airFind(
+          'People',
+          `RECORD_ID() = '${lastGrant.fields['Leader'][0]}'`
+        )
+      ).fields['Slack ID']
+      await bot.replyPrivateDelayed(
+        message,
+        transcript('promos.githubGrant.alreadyGranted', {
+          lastGrantDate,
+          requester,
+        })
+      )
+      return
+    }
 
-//     if (!history.isActive) {
-//       await bot.replyPrivateDelayed(
-//         message,
-//         transcript('promos.githubGrant.inactive')
-//       )
-//     }
+    if (!history.isActive) {
+      await bot.replyPrivateDelayed(
+        message,
+        transcript('promos.githubGrant.inactive')
+      )
+    }
 
-//     const grant = await airCreate('GitHub Grants', {
-//       Club: [club.id],
-//       Leader: [leader.id],
-//       Type: 'Semesterly ($50)',
-//       'Grant amount': 50,
-//     })
+    const grant = await airCreate('GitHub Grants', {
+      Club: [club.id],
+      Leader: [leader.id],
+      Type: 'Semesterly ($50)',
+      'Grant amount': 50,
+    })
 
-//     bot.replyPrivateDelayed(
-//       message,
-//       transcript('promos.githubGrant.requestForm', { id: grant.id })
-//     )
-//   }
-// }
+    bot.replyPrivateDelayed(
+      message,
+      transcript('promos.githubGrant.requestForm', { id: grant.id })
+    )
+  }
+}

--- a/src/interactions/promos/githubGrant.js
+++ b/src/interactions/promos/githubGrant.js
@@ -1,139 +1,139 @@
-import {
-  initBot,
-  getInfoForUser,
-  airFind,
-  airCreate,
-  transcript,
-} from '../../utils'
-import interactionMailMission from '../mailMission'
+// import {
+//   initBot,
+//   getInfoForUser,
+//   airFind,
+//   airCreate,
+//   transcript,
+// } from '../../utils'
+// import interactionMailMission from '../mailMission'
 
-/*
-to test
-[ ] mailteam request vanilla grant
-[ ] mailteam request recurring grant (valid)
-[ ] mailteam request recurring grant (already had grant this semester)
-[ ] hcb request vanilla grant
-[ ] hcb request recurring grant (valid)
-[ ] hcb request recurring grant (already had grant this semester)
-[ ] request from non leader
-*/
-export const names = ['GitHub Grant', 'club grant']
-export const details =
-  'Available to club leaders. Must have a meeting time set with `/meeting-time`'
+// /*
+// to test
+// [ ] mailteam request vanilla grant
+// [ ] mailteam request recurring grant (valid)
+// [ ] mailteam request recurring grant (already had grant this semester)
+// [ ] hcb request vanilla grant
+// [ ] hcb request recurring grant (valid)
+// [ ] hcb request recurring grant (already had grant this semester)
+// [ ] request from non leader
+// */
+// export const names = ['GitHub Grant', 'club grant']
+// export const details =
+//   'Available to club leaders. Must have a meeting time set with `/meeting-time`'
 
-export async function run(bot, message) {
-  const { user } = message
-  const { leader, club, history, personAddress } = await getInfoForUser(user)
+// export async function run(bot, message) {
+//   const { user } = message
+//   const { leader, club, history, personAddress } = await getInfoForUser(user)
 
-  if (!leader || !club) {
-    await bot.replyPrivateDelayed(
-      message,
-      transcript('promos.githubGrant.notAuthorized')
-    )
-    return
-  }
+//   if (!leader || !club) {
+//     await bot.replyPrivateDelayed(
+//       message,
+//       transcript('promos.githubGrant.notAuthorized')
+//     )
+//     return
+//   }
 
-  await bot.replyPrivateDelayed(
-    message,
-    transcript('promos.githubGrant.programClosed')
-  )
-  return // we're closing down grants this semester until we get more funding from GitHub
+//   await bot.replyPrivateDelayed(
+//     message,
+//     transcript('promos.githubGrant.programClosed')
+//   )
+//   return // we're closing down grants this semester until we get more funding from GitHub
 
-  const lastGrant = await airFind(
-    'GitHub Grants',
-    `AND({Dummy} = 0, {Club} = '${club.fields['ID']}')`,
-    null,
-    {
-      selectBy: {
-        sort: [{ field: 'Initiated at', direction: 'desc' }],
-      },
-    }
-  )
-  if (!lastGrant) {
-    // this is their first grant
-    const grant = await airCreate('GitHub Grants', {
-      Club: [club.id],
-      Leader: [leader.id],
-      Type: 'First meeting ($100)',
-      'Grant amount': 100,
-    })
+//   const lastGrant = await airFind(
+//     'GitHub Grants',
+//     `AND({Dummy} = 0, {Club} = '${club.fields['ID']}')`,
+//     null,
+//     {
+//       selectBy: {
+//         sort: [{ field: 'Initiated at', direction: 'desc' }],
+//       },
+//     }
+//   )
+//   if (!lastGrant) {
+//     // this is their first grant
+//     const grant = await airCreate('GitHub Grants', {
+//       Club: [club.id],
+//       Leader: [leader.id],
+//       Type: 'First meeting ($100)',
+//       'Grant amount': 100,
+//     })
 
-    if (grant.fields['HCB Account']) {
-      // if they have an HCB account, we'll notify the bank team
-      await bot.replyPrivateDelayed(
-        message,
-        transcript('promos.githubGrant.hcbFulfillment', {
-          hcbLink: grant.fields['HCB Account'],
-        })
-      )
-    } else if (
-      personAddress.fields['Country'] === 'United States of America (US)'
-    ) {
-      // if no HCB account, check if they're in the US. If so, setup a mail mission
-      await interactionMailMission(undefined, {
-        user,
-        text: 'new_club_grant',
-      })
-      await bot.replyPrivateDelayed(
-        message,
-        transcript('promos.githubGrant.usShipping')
-      )
-    } else {
-      // if no HCB account
-      await bot.replyPrivateDelayed(
-        message,
-        transcript('promos.githubGrant.otherSuccess')
-      )
-    }
-    return
-  } else {
-    // they've had a grant before
-    const lastGrantDate = new Date(lastGrant.fields['Initiated at'])
-    const today = new Date()
+//     if (grant.fields['HCB Account']) {
+//       // if they have an HCB account, we'll notify the bank team
+//       await bot.replyPrivateDelayed(
+//         message,
+//         transcript('promos.githubGrant.hcbFulfillment', {
+//           hcbLink: grant.fields['HCB Account'],
+//         })
+//       )
+//     } else if (
+//       personAddress.fields['Country'] === 'United States of America (US)'
+//     ) {
+//       // if no HCB account, check if they're in the US. If so, setup a mail mission
+//       await interactionMailMission(undefined, {
+//         user,
+//         text: 'new_club_grant',
+//       })
+//       await bot.replyPrivateDelayed(
+//         message,
+//         transcript('promos.githubGrant.usShipping')
+//       )
+//     } else {
+//       // if no HCB account
+//       await bot.replyPrivateDelayed(
+//         message,
+//         transcript('promos.githubGrant.otherSuccess')
+//       )
+//     }
+//     return
+//   } else {
+//     // they've had a grant before
+//     const lastGrantDate = new Date(lastGrant.fields['Initiated at'])
+//     const today = new Date()
 
-    // our heuristic for keeping 1 grant per semester is to check if the last grant was both this semester & this year
-    // semesters are defined as:
-    // - first semester months are 6 through 11
-    // - second semester months are 0 through 5
-    const currentSemester = Math.floor(today.getMonth() / 5)
-    const lastGrantSemester = Math.floor(lastGrantDate.getMonth() / 5)
+//     // our heuristic for keeping 1 grant per semester is to check if the last grant was both this semester & this year
+//     // semesters are defined as:
+//     // - first semester months are 6 through 11
+//     // - second semester months are 0 through 5
+//     const currentSemester = Math.floor(today.getMonth() / 5)
+//     const lastGrantSemester = Math.floor(lastGrantDate.getMonth() / 5)
 
-    const hasSameYear = lastGrantDate.getYear() == today.getYear()
-    const hasSameSemester = lastGrantSemester == currentSemester
-    if (hasSameYear && hasSameSemester) {
-      const requester = (
-        await airFind(
-          'People',
-          `RECORD_ID() = '${lastGrant.fields['Leader'][0]}'`
-        )
-      ).fields['Slack ID']
-      await bot.replyPrivateDelayed(
-        message,
-        transcript('promos.githubGrant.alreadyGranted', {
-          lastGrantDate,
-          requester,
-        })
-      )
-      return
-    }
+//     const hasSameYear = lastGrantDate.getYear() == today.getYear()
+//     const hasSameSemester = lastGrantSemester == currentSemester
+//     if (hasSameYear && hasSameSemester) {
+//       const requester = (
+//         await airFind(
+//           'People',
+//           `RECORD_ID() = '${lastGrant.fields['Leader'][0]}'`
+//         )
+//       ).fields['Slack ID']
+//       await bot.replyPrivateDelayed(
+//         message,
+//         transcript('promos.githubGrant.alreadyGranted', {
+//           lastGrantDate,
+//           requester,
+//         })
+//       )
+//       return
+//     }
 
-    if (!history.isActive) {
-      await bot.replyPrivateDelayed(
-        message,
-        transcript('promos.githubGrant.inactive')
-      )
-    }
+//     if (!history.isActive) {
+//       await bot.replyPrivateDelayed(
+//         message,
+//         transcript('promos.githubGrant.inactive')
+//       )
+//     }
 
-    const grant = await airCreate('GitHub Grants', {
-      Club: [club.id],
-      Leader: [leader.id],
-      Type: 'Semesterly ($50)',
-      'Grant amount': 50,
-    })
+//     const grant = await airCreate('GitHub Grants', {
+//       Club: [club.id],
+//       Leader: [leader.id],
+//       Type: 'Semesterly ($50)',
+//       'Grant amount': 50,
+//     })
 
-    bot.replyPrivateDelayed(
-      message,
-      transcript('promos.githubGrant.requestForm', { id: grant.id })
-    )
-  }
-}
+//     bot.replyPrivateDelayed(
+//       message,
+//       transcript('promos.githubGrant.requestForm', { id: grant.id })
+//     )
+//   }
+// }

--- a/src/interactions/promos/replitHackerPlan.js
+++ b/src/interactions/promos/replitHackerPlan.js
@@ -1,0 +1,26 @@
+import { transcript } from '../../utils'
+
+export const names = [
+  'Replit',
+  'Repl.it',
+  'Repl.it Hacker Plan',
+  'Replit Hacker Plan',
+  'Repl.it Hacker',
+  'Replit Hacker'
+]
+
+export const details = 'Available to anyone'
+export async function run(bot, message) {
+  const { user } = message
+  const { leader, club } = await getInfoForUser(user)
+
+  if (!leader || !club) {
+    await bot.replyPrivateDelayed(
+      message,
+      transcript('promos.replit.notAuthorized')
+    )
+    return
+  }
+
+  await bot.replyPrivateDelayed(message, transcript('promos.replit.success'))
+}

--- a/src/interactions/promos/replitHackerPlan.js
+++ b/src/interactions/promos/replitHackerPlan.js
@@ -1,4 +1,4 @@
-import { transcript } from '../../utils'
+import { transcript, getInfoForUser } from '../../utils'
 
 export const names = [
   'Replit',

--- a/src/utils/transcript.yml
+++ b/src/utils/transcript.yml
@@ -404,6 +404,9 @@ promos:
     success: You and all your club members can use this link to apply hack.af/pack. Make sure to select "${this.referrer}" in the "Hack Club / Hackathon" field.
   notion: Go to hack.af/ntn for instructions on how to get your free Notion account
   adafruit: Go to adafruit.com and use \`HACKCLUB\` as a promo code to get a 10% discount! 
+  replit:
+    success: Go to https://repl.it/claim?code=h4ckc1ub21 to claim a free Hacker Plan. Feel free to share this with your coleads and club members, but nobody else (we have a limited amount of codes available).
+    notAuthorized: This can only be run by club leaders. I can't find your club's record in my database.
   githubGrant:
     programClosed: |
       We've given out all the money from GitHub's grant fund from the 2019-2020 school year. We're currently talking to them about renewing the fund for next year, so check back later.


### PR DESCRIPTION
Since the repl.it hacker plan code [was on the Toolbox without any auth](https://hackclub.slack.com/archives/C7YM49ULC/p1613932734006500?thread_ts=1613861161.003700&cid=C7YM49ULC), it got out to a lot more people than just hack club leaders and their members. This puts the new code behind `/get` and restricts it only to club leaders.

This PR also comments out the code in the GitHub Grant file, since that still appears in `/get` even though we aren't doing it this year.