### PR TITLE
Invite tagged user to channels on `/leader-add`

### DIFF
--- a/src/interactions/leaderAdd.js
+++ b/src/interactions/leaderAdd.js
@@ -36,6 +36,18 @@ const interactionLeaderAdd = async (bot, message) => {
     Clubs: [...taggedUserClubs, recipientClub.id],
   })
 
+  // invite leader to #leaders and their club channel
+  bot.api.conversations.invite({
+    token: bot.config.bot.access_token,
+    channel,
+    users: taggedUserID
+  })
+  bot.api.conversations.invite({
+    token: bot.config.bot.access_token,
+    channel: 'GAE0FFNFN',
+    users: taggedUserID
+  })
+
   bot.replyPrivateDelayed(
     message,
     transcript('leaderAdd.success', { taggedUserID, channel })


### PR DESCRIPTION
Today I noticed that about a third of all US club leaders had never been added to the `#leaders` channel on Slack because we previously didn't have systems in place to add them. I added a step to the bouncer workflows to automatically invite new leaders to `#leaders`—the only thing left is the `/leader-add` command in Orpheus. This PR automatically invites tagged users to `#leaders` and their club channels.