### PR TITLE
Deprecate Secret Tickets

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -312,34 +312,6 @@ controller.on('slash_command', async (bot, message) => {
   )
 })
 
-controller.on('reaction_added', async (bot, message) => {
-  bot.replyAcknowledge()
-  const { reaction, user, item } = message
-  const { channel } = item
-  if (reaction == 'admission_tickets') {
-    if (channel == 'C0P5NE354' /* #bot-spam */ || channel == 'C0266FRGT' /* #announcements */) {
-      bot.say({
-        channel: user,
-        text: transcript('secretProject.ticket', {user}),
-        blocks: [
-          {
-            type: "section",
-            text: {
-              type: "mrkdwn",
-              text: transcript('secretProject.ticket', {user})
-            }
-          },
-          {
-            "type": "image",
-            "image_url": transcript('secretProject.image', {user}),
-            "alt_text": "Your ticket"
-          }
-        ]}
-      )
-    }
-  }
-})
-
 controller.on('block_actions', (bot, message) => {
   try {
     const { channel, text } = message

--- a/src/utils/transcript.yml
+++ b/src/utils/transcript.yml
@@ -545,10 +545,3 @@ reportForm:
       elements:
         - type: 'mrkdwn'
           text: 'Optionally include extra details in the notes field.'
-secretProject:
-  ticket: |
-    Howdy there! Let's see that ticket
-    _ka- *chunk_* :ticket_punched:
-    Here you go! <https://tickets.hackclub.com/${this.user}|Your RSVP is confirmed.>
-    The call will happen in https://hack.af/summer-secret
-  image: https://tickets.hackclub.com/api/ticket?username=${this.user}


### PR DESCRIPTION
Two reasons:

1. I think it's cool to keep them exculsive
2. The code that generates them has been taken down so new ones can't be created, only old ones viewed