### PR TITLE
gIvE hEr SoMe SaSs

### DIFF
--- a/app/interactions/mocking_spongebob.rb
+++ b/app/interactions/mocking_spongebob.rb
@@ -1,0 +1,53 @@
+module MockingString
+  refine String do
+    def reverse_case
+      if self == self.upcase
+        self.downcase
+      else
+        self.upcase
+      end
+    end
+
+    def to_mock
+      # this'd be simple with just a plain old
+      # chars.each_with_index.map { |c, i| i.even? ? c.downcase : c.upcase }.join
+      # but we're getting more complex because stuff in <tags> on slack fails to
+      # render in some clients when capitalization is played with
+
+      in_bracket = 0
+
+      chars.each_with_index.map do |c, i|
+        case c
+        when '<'
+          in_bracket += 1
+          c
+        when '>'
+          in_bracket -= 1
+          c
+        else
+          if i.even? && in_bracket == 0
+            c.reverse_case
+          else
+            c
+          end
+        end
+      end.join
+    end
+  end
+end
+
+class MockingSpongebob < Interaction
+  using MockingString
+  handle :app_mention
+
+  checklist do
+    check { rand < 0.1 }
+    message_shorter_than 100
+    # bot is mentioned
+  end
+
+  def call
+    message = event[:text]
+    reply_in_thread ":spongebob-mocking: #{message.to_mock}"
+  end
+end


### PR DESCRIPTION
This is a deeply questionable feature, however, consider the following:

<img width="428" height="179" alt="Screenshot 2026-02-20 at 01 37 21" src="https://github.com/user-attachments/assets/370fa3cb-f986-4514-8db9-9678c4a75e49" />
<img width="510" height="219" alt="Screenshot 2026-02-20 at 01 37 12" src="https://github.com/user-attachments/assets/5cecb52f-1072-4cde-9faf-4f076fdbc948" />
<img width="300" height="188" alt="Screenshot 2026-02-20 at 01 36 19" src="https://github.com/user-attachments/assets/55cef966-9bd6-4c6a-a412-5de1b399bc7f" />
<img width="433" height="176" alt="Screenshot 2026-02-20 at 01 35 31" src="https://github.com/user-attachments/assets/089f0b66-c443-409c-88d6-64ae2839829b" />

there's a 10% chance when she's tagged-- this doesn't implement the old feature of checking name mention (ie. "orpheus"), you need to directly tag her