### PR TITLE
Add chess battle advanced interaction

### DIFF
--- a/app/interactions/chess_battle_advanced.rb
+++ b/app/interactions/chess_battle_advanced.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class ChessBattleAdvanced < Interaction
+  handle :message
+
+  checklist do
+    message_text_matches /.*chess battle advanced.*$/i
+    event_has_user
+    user_not_bot
+  end
+
+  def call
+    message_info = { channel: event[:channel] || event[:channel_id], event_ts: event[:thread_ts] || event[:event_ts] || event[:ts] }
+
+    begin
+      reply_in_thread "https://cdn.hackclub.com/019e4030-69ed-7e05-b6ce-d31cd5274183/1z7eh.mp4", message: message_info
+    rescue Slack::Web::Api::Errors::NotInChannel
+      logger.info "[chess_battle_advanced] not in channel: #{event[:channel]}"
+    end
+  end
+end


### PR DESCRIPTION
When saying a message that has `chess battle advanced` in it, it will reply with the URL [`https://cdn.hackclub.com/019e4030-69ed-7e05-b6ce-d31cd5274183/1z7eh.mp4`](https://cdn.hackclub.com/019e4030-69ed-7e05-b6ce-d31cd5274183/1z7eh.mp4). (icely puzzles reference)

if you do not want a CDN link you can change it to https://www.youtube.com/watch?v=ojzPab3ap0Y (extended) or https://streamable.com/1z7eh (original but not youtube)